### PR TITLE
Bump chef-workstation to 20.7.96

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask 'chef-workstation' do
-  version '0.17.5'
-  sha256 'invalid, testing'
+  version '20.7.96'
+  sha256 'b0ab6bba23d3cd5ef2e1e4cad2dbbffd34ac6fe4b3cfe5df62c298c367b7a9cd'
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
   appcast 'https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.14&m=x86_64&v=latest'


### PR DESCRIPTION
After making all changes to the cask:
 - [x] `brew cask audit --download Casks/chef-workstation.rb` is error-free.
 - [x] `brew cask style --fix Casks/chef-workstation.rb` reports no offenses.
 - [x] The commit message includes the cask’s name and version.
 - [x] The submission is for stable version.
